### PR TITLE
Fixes: #24 - Remove Quiet on Cmake definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,17 +42,17 @@ endif()
 
 
 
-find_package(OpenSSL CONFIG QUIET)
+find_package(OpenSSL CONFIG)
 if (NOT OpenSSL_FOUND)
     find_package(OpenSSL REQUIRED)
 endif()
 
-find_package(CURL CONFIG QUIET)
+find_package(CURL CONFIG)
 if (NOT CURL_FOUND)
     find_package(CURL REQUIRED)
 endif()
 
-find_package(exiv2 CONFIG QUIET)
+find_package(exiv2 CONFIG)
 if (NOT exiv2_FOUND)
     find_package(exiv2 REQUIRED)
 endif()

--- a/cmake/CpuFeatures.cmake
+++ b/cmake/CpuFeatures.cmake
@@ -1,4 +1,4 @@
-find_package(CpuFeatures QUIET)
+find_package(CpuFeatures)
 
 if (NOT TARGET CpuFeatures::CpuFeatures)
 # CPU Features dependency

--- a/cmake/wxWidgets.cmake
+++ b/cmake/wxWidgets.cmake
@@ -22,9 +22,9 @@ if (NOT WIN32)
 
     if (NOT WXWIDGETS_EXTRA_PATH STREQUAL "")
         message(STATUS "Using extra search path: ${WXWIDGETS_EXTRA_PATH}")
-        find_package(wxWidgets ${WXWIDGETS_VERSION} QUIET PATHS ${WXWIDGETS_EXTRA_PATH})
+        find_package(wxWidgets ${WXWIDGETS_VERSION} PATHS ${WXWIDGETS_EXTRA_PATH})
     else()
-        find_package(wxWidgets ${WXWIDGETS_VERSION} QUIET)
+        find_package(wxWidgets ${WXWIDGETS_VERSION})
     endif()
 
     if (wxWidgets_FOUND)


### PR DESCRIPTION
Quiet suppresses debugging information that's useful. After applying this patch, I was rather quickly able to find out why wxWidgets was unable to be found (It was because the WXWIDGETS_VERSION I was passing in was too specific, 3.2.8.1 instead of 3.2.8).

The Quiet part of the cmake only serves to inconvenience package maintainers and should be removed under this guise.